### PR TITLE
Updating a test

### DIFF
--- a/tests/test_globalapi.py
+++ b/tests/test_globalapi.py
@@ -262,8 +262,6 @@ def test_getGuildUpgrade():
     assert type(upgrade).__name__ == 'GuildUpgrade'
     assert upgrade.name == 'Guild Treasure Trove'
 
-    assert 58 in upgrade.prerequisites
-
     # Test all
     assert len(gAPI.getGuildUpgrade('all')) > 20
 


### PR DESCRIPTION
They changed the prerequisites of the underlying return data for the item in the game which broke the test.