### PR TITLE
Fix for failing test. Object name in endpoint was changed upstream.

### DIFF
--- a/tests/test_accountapi.py
+++ b/tests/test_accountapi.py
@@ -117,7 +117,7 @@ def test_getBank():
 
 def test_getAchievements():
     assert len(api.getAchievements()) > 5
-    assert api.achievements[0]['object'].name == 'Centaur Slayer'
+    assert api.achievements[0]['object'].name == 'Citadel of Flame Foe'
 
     for unit in api.achievements:
         assert type(unit['object']).__name__ == 'Achievement'


### PR DESCRIPTION
>       assert api.achievements[0]['object'].name == 'Centaur Slayer'
E       AssertionError: assert 'Citadel of Flame Foe' == 'Centaur
Slayer'
E         - Centaur Slayer
E         + Citadel of Flame Foe

tests/test_accountapi.py:120: AssertionError